### PR TITLE
GrobArray erase

### DIFF
--- a/lume/include/lume/edge_mesh_2d.h
+++ b/lume/include/lume/edge_mesh_2d.h
@@ -79,12 +79,12 @@ public:
   bool add_edge (Edge const& edge, Boundary boundary = Boundary::None);
   bool has_edge (Edge const& edge) const;
   void remove_edge (Edge const& edge);
-  void remove_edges_with_vertex (index_t vertex);
+  void remove_edges_with_vertex (index_t vertex, bool addBoundaryMarkers);
   
+  Connections const& connections (index_t vertex) const;
+
   bool swap_edge (Edge const& edge);
   
-  Connections const& vertex_connections (index_t vertex) const;
-
   GrobArray create_triangles () const;
 
 private:
@@ -97,6 +97,7 @@ private:
   double compute_pseudo_angle (index_t const from, index_t const to) const;
   bool is_valid (Edge const& edge) const;
 
+  Connections const& vertex_connections (index_t vertex) const;
   Connections& vertex_connections (index_t vertex);
 
   bool has_connection (index_t const from, index_t const to) const;

--- a/lume/include/lume/grob.h
+++ b/lume/include/lume/grob.h
@@ -38,8 +38,95 @@
 
 namespace lume {
 
+class Grob;
+
 // TODO: CREATE CONST GROB
+/// A ConstGrob represents a const reference to a **grid object**, specified by its corner indices.
+/** To create a `ConstGrob`, pass the `grobType` and an array of corner-indices
+ * (`corners`) to the constructor. `corners`has to have at least length
+ * `GridDesc(grobType).num_corners()`.
+ *
+ * \warning Since a `ConstGrob` instance stores a pointer to the specified array
+ *      of corners, an instance is invalidated once the pointer does no longer
+ *      point to a valid memory location (e.g. because the underlying corner
+ *      array has been resized). A `ConstGrob` thus should only be used as a
+ *      temporary object and should only be used if it is clear that the
+ *      underlying coner-array is still valid.
+ */   
+class ConstGrob
+{
+public:
+  /// Defines the maximum number of corners that any `Grob` may have.
+  /** For all Grobs `g` holds: `g.num_grobs() <= Grob::maxNumCorners`.
+      \note This limitation arises from the use of Array_16_4 which is used to
+            store local corner indices*/
+  static constexpr index_t maxNumCorners = 16;
+
+  using CornerIndexContainer = std::array <index_t, maxNumCorners>;
+public:
+  ConstGrob (GrobType grobType, index_t const* corners = nullptr);
+  ConstGrob (ConstGrob const& other);
+  ConstGrob (Grob const& other);
+
+  /// Creates a `Grob` from an indexArray and a table of offsets for each corner into that array.
+  ConstGrob (GrobType grobType, index_t const* globCornerInds, const impl::Array_16_4& cornerOffsets);
+
+  /// Resets the grob so that it now operates as a reference to the data of `other`.
+  /** \{ */
+  void reset (Grob const& other);
+  void reset (ConstGrob const& other);
+  /** \} */
+
+  void set_global_corner_array (index_t const* cornerArray);
+
+  ///  only compares corners, ignores order and orientation.
+  bool operator == (const ConstGrob& g) const;
+  bool operator != (const ConstGrob& g) const;
+
+  index_t operator [] (const index_t i) const;
+
+  index_t dim () const;
   
+  GrobType grob_type () const;
+  
+  GrobDesc desc () const;
+
+  index_t const* global_corner_array () const;
+
+  index_t num_corners () const;
+
+  /// returns the global index of the i-th corner
+  index_t corner (const index_t i) const;
+
+  /// collects the global indices of corners
+  /** \param cornersOut  Array of size `Grob::max_num_corners(). Only the first
+     *                      `Grob::num_corners()` entries are filled
+   *
+   * \returns  The number of corners of the specified side
+   */
+  index_t collect_corners (CornerIndexContainer& cornersOut) const;
+
+  index_t num_sides (const index_t sideDim) const;
+  
+  GrobDesc side_desc (const index_t sideDim, const index_t sideIndex) const;
+
+  ConstGrob side (const index_t sideDim, const index_t sideIndex) const;
+
+  /// returns the index of the side which corresponds to the given grob
+  /** if no such side was found, 'lume::NO_INDEX' is returned.*/
+  index_t find_side (const ConstGrob& sideGrob) const;
+
+  /** Returns a special array object which contains for each corner the offset into the
+    underlying globalCornerInds array.
+    \note This method is typically not relevant for users of the library.*/
+  const impl::Array_16_4& corner_offsets () const;
+
+private:
+  index_t const*   m_globCornerInds {nullptr};
+  impl::Array_16_4 m_cornerOffsets;
+  GrobDesc         m_desc {lume::VERTEX};
+};
+
 /// A Grob represents a reference to a **grid object**, specified by its corner indices.
 /** To create a `Grob`, pass the `grobType` and an array of corner-indices
  * (`corners`) to the constructor. `corners`has to have at least length
@@ -48,13 +135,13 @@ namespace lume {
  * A Grob behaves like a reference object, i.e., assigning corners (or another grob)
  * will change the content of the underlying corner array.
  *
- * \warning	Since a `Grob` instance stores a pointer to the specified array
- *			of corners, an instance is invalidated once the pointer does no longer
- *			point to a valid memory location (e.g. because the underlying corner
- *			array has been resized). A `Grob` thus should only be used as a
- *			temporary object and should only be used if it is clear that the
- *			underlying coner-array is still valid.
- */
+ * \warning Since a `Grob` instance stores a pointer to the specified array
+ *      of corners, an instance is invalidated once the pointer does no longer
+ *      point to a valid memory location (e.g. because the underlying corner
+ *      array has been resized). A `Grob` thus should only be used as a
+ *      temporary object and should only be used if it is clear that the
+ *      underlying coner-array is still valid.
+ */ 
 class Grob
 {
 public:
@@ -66,188 +153,73 @@ public:
 
   using CornerIndexContainer = std::array <index_t, maxNumCorners>;
 
-  Grob () = default;
+public:
+  Grob (GrobType grobType, index_t* corners = nullptr);
+  Grob (Grob const& other);
 
-	Grob (GrobType grobType, index_t* corners = nullptr) :
-		m_globCornerInds (corners),
-		m_cornerOffsets (impl::Array_16_4::ascending_order ()),
-		m_desc (grobType)
-	{}
+  /// Creates a `Grob` from an indexArray and a table of offsets for each corner into that array.
+  Grob (GrobType grobType, index_t* indexArray, const impl::Array_16_4& cornerOffsets);
 
-  Grob (Grob const& other)
-    : m_globCornerInds {other.m_globCornerInds}
-    , m_cornerOffsets {other.m_cornerOffsets}
-    , m_desc {other.m_desc}
-  {}
+  /// Resets the grob so that it now operates as a reference to the data of `other`.
+  void reset (Grob const& other);
 
-  Grob (Grob&& other)
-    : m_globCornerInds {other.m_globCornerInds}
-    , m_cornerOffsets {other.m_cornerOffsets}
-    , m_desc {other.m_desc}
-  {}
+  void set_global_corner_array (index_t* cornerArray);
 
-  Grob& operator = (Grob const& other)
-  {
-    assert (m_globCornerInds != nullptr);
-    assert (other.m_globCornerInds != nullptr);
-    assert (other.grob_type () == grob_type ());
-    assert (other.num_corners () == num_corners ());
+  Grob& operator = (Grob const& other);
+  Grob& operator = (ConstGrob const& other);
 
-    index_t const numCorners = num_corners ();
-    for (index_t i = 0; i < numCorners; ++i)
-    {
-      set_corner (i, other [i]);
-    }
+  /// only compares corners, ignores order and orientation.
+  bool operator == (const Grob& g) const;
+  bool operator == (const ConstGrob& g) const;
+  bool operator != (const Grob& g) const;
+  bool operator != (const ConstGrob& g) const;
 
-    return *this;
-  }
+  index_t operator [] (const index_t i) const;
 
-  Grob& operator = (Grob&& other)
-  {
-    return this->operator = (other);
-  }
+  index_t dim () const;
+  
+  GrobType grob_type () const;
+  
+  GrobDesc desc () const;
 
-	///	only compares corners, ignores order and orientation.
-	bool operator == (const Grob& g) const
-	{
-		if (m_desc.grob_type() != g.m_desc.grob_type())
-			return false;
+  const index_t* global_corner_array () const;
 
-		CornerIndexContainer gCorners;
-		g.collect_corners (gCorners);
+  index_t* global_corner_array ();
 
-		const index_t numCorners = num_corners ();
-		for(index_t i = 0; i < numCorners; ++i) {
-			bool gotOne = false;
-			const index_t c = corner(i);
-			for(index_t j = 0; j < numCorners; ++j) {
-				if(c == gCorners [j]){
-					gotOne = true;
-					break;
-				}
-			}
+  index_t num_corners () const;
 
-			if (!gotOne)
-				return false;
-		}
-
-		return true;
-	}
-
-	bool operator != (const Grob& g) const
-	{
-		return !((*this) == g);
-	}
-
-  inline index_t operator [] (const index_t i) const
-  {
-    return corner (i);
-  }
-
-	inline index_t dim () const        {return m_desc.dim ();}
-	
-	inline GrobType grob_type () const {return m_desc.grob_type ();}
-	
-	inline GrobDesc desc () const      {return m_desc;}
-
-	inline void set_global_corner_array (index_t* corners)
-	{
-		m_globCornerInds = corners;
-	}
-
-	inline const index_t* global_corner_array () const
-	{
-		return m_globCornerInds;
-	}
-
-  inline index_t* global_corner_array ()
-  {
-    return m_globCornerInds;
-  }
-
-	inline index_t num_corners () const					{return m_desc.num_corners();}
-
-	/// returns the global index of the i-th corner
-	inline index_t corner (const index_t i) const
-	{
-    assert (m_globCornerInds != nullptr);
-		return m_globCornerInds [m_cornerOffsets.get(i)];
-	}
+  /// returns the global index of the i-th corner
+  index_t corner (const index_t i) const;
 
   /// sets the point index of the i-th corner
-  inline void set_corner (const index_t cornerIndex, const index_t pointIndex)
-  {
-    assert (m_globCornerInds != nullptr);
-    assert (cornerIndex < num_corners ());
-    m_globCornerInds [m_cornerOffsets.get(cornerIndex)] = pointIndex;
-  }
+  void set_corner (const index_t cornerIndex, const index_t pointIndex);
 
-	/// collects the global indices of corners
-	/** \param cornersOut	Array of size `Grob::max_num_corners(). Only the first
+  /// collects the global indices of corners
+  /** \param cornersOut Array of size `Grob::max_num_corners(). Only the first
      *                      `Grob::num_corners()` entries are filled
-	 *
-	 * \returns	The number of corners of the specified side
-	 */
-	inline index_t collect_corners (CornerIndexContainer& cornersOut) const
-	{
-    assert (m_globCornerInds != nullptr);
-		const index_t numCorners = num_corners();
-		for(index_t i = 0; i < numCorners; ++i)
-			cornersOut[i] = static_cast<index_t> (m_globCornerInds [m_cornerOffsets.get(i)]);
-		return numCorners;
-	}
+   *
+   * \returns The number of corners of the specified side
+   */
+  index_t collect_corners (CornerIndexContainer& cornersOut) const;
 
-	inline index_t num_sides (const index_t sideDim) const
-	{
-		return m_desc.num_sides(sideDim);
-	}
-	
-	inline GrobDesc side_desc (const index_t sideDim, const index_t sideIndex) const
-	{
-		return m_desc.side_desc (sideDim, sideIndex);
-	}
+  index_t num_sides (const index_t sideDim) const;
+  
+  GrobDesc side_desc (const index_t sideDim, const index_t sideIndex) const;
 
-	Grob side (const index_t sideDim, const index_t sideIndex) const
-	{
-    assert (m_globCornerInds != nullptr);
-		impl::Array_16_4 cornerOffsets;
-		const index_t numCorners = m_desc.side_desc(sideDim, sideIndex).num_corners();
-		const index_t* locCorners = m_desc.local_side_corners (sideDim, sideIndex);
-		// LOGT(side, "side " << sideIndex << "(dim: " << sideDim << ", num corners: " << numCorners << "): ");
-		for(index_t i = 0; i < numCorners; ++i){
-			// LOG(locCorners[i] << " ");
-			cornerOffsets.set (i, m_cornerOffsets.get(locCorners[i]));
-		}
-		// LOG("\n");
+  Grob side (const index_t sideDim, const index_t sideIndex) const;
 
-		return Grob (m_desc.side_type (sideDim, sideIndex), m_globCornerInds, cornerOffsets);
-	}
+  /// returns the index of the side which corresponds to the given grob
+  /** if no such side was found, 'lume::NO_INDEX' is returned.*/
+  index_t find_side (const Grob& sideGrob) const;
 
-	/// returns the index of the side which corresponds to the given grob
-	/** if no such side was found, 'lume::NO_INDEX' is returned.*/
-	index_t find_side (const Grob& sideGrob) const
-	{
-		const index_t sideDim = sideGrob.dim();
-		const index_t numSides = num_sides (sideDim);
-		for(index_t iside = 0; iside < numSides; ++iside) {
-			if (sideGrob == side (sideDim, iside))
-				return iside;
-		}
-		return NO_INDEX;
-	}
+  const impl::Array_16_4& corner_offsets () const;
 
 private:
-	Grob (GrobType grobType, index_t* globCornerInds, const impl::Array_16_4& cornerOffsets) :
-		m_globCornerInds (globCornerInds),
-		m_cornerOffsets (cornerOffsets),
-		m_desc (grobType)
-	{}
-
-	index_t*         m_globCornerInds {nullptr};
-	impl::Array_16_4 m_cornerOffsets;
-	GrobDesc         m_desc {lume::VERTEX};
+  /** The data stored in the ConstGrob will be used here even for non-const operations.
+    This reduces code duplication and is save, since the internal ConstGrob is solely used
+    in this non-const environment.*/ 
+  ConstGrob m_constGrob;
 };
+}//  end of namespace lume
 
-}//	end of namespace lume
-
-#endif	//__H__lume__grob
+#endif  //__H__lume__grob

--- a/lume/include/lume/grob_array.h
+++ b/lume/include/lume/grob_array.h
@@ -118,18 +118,39 @@ public:
       push_back (grob);
   }
 
-	inline const Grob operator [] (const size_type i) const	{return Grob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
+  iterator erase (iterator begin, iterator end)
+  {
+    auto newIter = m_array.erase (tuple_iterator (begin), tuple_iterator (end));
+    if (newIter == m_array.end ())
+      return this->end ();
+    return GrobIterator (m_grobDesc.grob_type (), m_array.data () + (newIter - m_array.begin ()));
+  }
 
-	inline iterator begin () const						{return GrobIterator (m_grobDesc.grob_type(), m_array.data());}
-	inline iterator end () const						{return GrobIterator (m_grobDesc.grob_type(), m_array.data() + m_array.size());}
+	inline Grob operator [] (const size_type i)            {return Grob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
+  inline ConstGrob operator [] (const size_type i) const {return Grob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
 
-	GrobDesc grob_desc () const							{return m_grobDesc;}
+	inline iterator begin ()             {return GrobIterator (m_grobDesc.grob_type(), m_array.data());}
+  inline const_iterator begin () const {return ConstGrobIterator (m_grobDesc.grob_type(), m_array.data());}
+
+	inline iterator end () 	           {return GrobIterator (m_grobDesc.grob_type(), m_array.data() + m_array.size());}
+  inline const_iterator end () const {return ConstGrobIterator (m_grobDesc.grob_type(), m_array.data() + m_array.size());}
+
+	GrobDesc grob_desc () const	{return m_grobDesc;}
 
 	TupleVector <index_t>& underlying_array ()				{return m_array;}
 	const TupleVector <index_t>& underlying_array () const	{return m_array;}
 
 private:
 	inline index_t num_grob_corners () const			{return m_grobDesc.num_corners();}
+  inline TupleVector <index_t>::iterator tuple_iterator (iterator const& i)
+  {
+    auto const* p = i->global_corner_array ();
+    assert (p > m_array.data ());
+    assert (static_cast <size_t> (p - m_array.data ()) <= m_array.size ());
+    return TupleVector <index_t>::iterator (m_array.begin () + (p - m_array.data ()));
+  }
+
+private:
 	GrobDesc				m_grobDesc;
 	TupleVector <index_t>	m_array;
 };

--- a/lume/include/lume/grob_array.h
+++ b/lume/include/lume/grob_array.h
@@ -39,7 +39,7 @@ namespace lume {
 class GrobArray {
 public:
 	using iterator = GrobIterator;
-	using const_iterator = GrobIterator;
+	using const_iterator = ConstGrobIterator;
   using size_type = TupleVector<index_t>::size_type;
   using value_type = index_t;
 
@@ -93,7 +93,7 @@ public:
 			m_array.push_back (i);
 	}
 
-	inline void push_back (const Grob& grob)
+	inline void push_back (const ConstGrob& grob)
 	{
 		using std::string;
 		using std::to_string;
@@ -127,7 +127,7 @@ public:
   }
 
 	inline Grob operator [] (const size_type i)            {return Grob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
-  inline ConstGrob operator [] (const size_type i) const {return Grob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
+  inline ConstGrob operator [] (const size_type i) const {return ConstGrob (m_grobDesc.grob_type(), m_array.data () + i * num_grob_corners());}
 
 	inline iterator begin ()             {return GrobIterator (m_grobDesc.grob_type(), m_array.data());}
   inline const_iterator begin () const {return ConstGrobIterator (m_grobDesc.grob_type(), m_array.data());}

--- a/lume/include/lume/grob_hash.h
+++ b/lume/include/lume/grob_hash.h
@@ -35,29 +35,31 @@
 
 namespace std
 {
-    template<> struct hash<lume::Grob>
+  template<> struct hash <lume::ConstGrob>
+  {
+    using argument_type = lume::ConstGrob;
+    using result_type = std::size_t;
+
+    result_type operator() (argument_type const& grob) const noexcept
     {
-        typedef lume::Grob argument_type;
-        typedef std::size_t result_type;
-        result_type operator()(argument_type const& grob) const noexcept
-        {
-        	using namespace lume;
-        	const index_t numCorners = grob.num_corners();
-        	index_t minIndex = std::numeric_limits <index_t>::max ();
-        	for(index_t i = 0; i < numCorners; ++i){
-        		minIndex = std::min (minIndex, grob.corner(i));
-        	}
-        	return 10^8 * (grob.grob_type () + 1) + static_cast <result_type> (minIndex);
-        }
-    };
-}//	end of namespace std
+      using namespace lume;
+      const index_t numCorners = grob.num_corners();
+      index_t minIndex = std::numeric_limits <index_t>::max ();
+      for(index_t i = 0; i < numCorners; ++i){
+        minIndex = std::min (minIndex, grob.corner(i));
+      }
+      return 10^8 * (grob.grob_type () + 1) + static_cast <result_type> (minIndex);
+    }
+  };
+}//  end of namespace std
 
 
-namespace lume {
-	using GrobHash = std::unordered_set <Grob>;
+namespace lume
+{
+  using GrobHash = std::unordered_set <ConstGrob>;
 
-	template <class T>
-	using GrobHashMap = std::unordered_map <Grob, T>;
-}//	end of namespace lume
+  template <class T>
+  using GrobHashMap = std::unordered_map <ConstGrob, T>;
+}//  end of namespace lume
 
-#endif	//__H__lume_grob_hash
+#endif  //__H__lume_grob_hash

--- a/lume/include/lume/grob_iterator.h
+++ b/lume/include/lume/grob_iterator.h
@@ -33,136 +33,138 @@
 
 namespace lume {
 
-class GrobIterator {
+template <class Grob>
+class GenericGrobIterator
+{
 public:
 	using iterator_category = std::bidirectional_iterator_tag;
 	using value_type = Grob;
 	using difference_type = std::ptrdiff_t;
 	using pointer = Grob*;
-  using const_pointer = const Grob*;
 	using reference = Grob&;
-  using const_reference = const Grob&;
 
-  GrobIterator () = default;
+  GenericGrobIterator () = default;
   
-  GrobIterator (GrobIterator const& other)
-   : m_grob (other.m_grob)
-   , m_numCorners (other.m_numCorners)
+  template <class GrobIterator>
+  GenericGrobIterator (GrobIterator const& other)
+   : m_grob (*other)
+   , m_numCorners (other->num_corners ())
   {}
 
-  GrobIterator (GrobIterator&& other)
-   : m_grob (other.m_grob)
-   , m_numCorners (other.m_numCorners)
-  {}
-
-	GrobIterator (GrobType grobType, index_t* globalCornerArray) :
+	GenericGrobIterator (GrobType grobType, index_t* globalCornerArray) :
 		m_grob (grobType, globalCornerArray),
 		m_numCorners (m_grob.num_corners ())
 	{}
 
-  GrobIterator& operator = (GrobIterator const& other)
+  GenericGrobIterator (GrobType grobType, index_t const* globalCornerArray) :
+    m_grob (grobType, globalCornerArray),
+    m_numCorners (m_grob.num_corners ())
+  {}
+
+  GenericGrobIterator& operator = (GenericGrobIterator const& other)
   {
-    m_grob       = other.m_grob;
+    m_grob.reset (other.m_grob);
     m_numCorners = other.m_numCorners;
     return *this;
   }
 
-  GrobIterator& operator = (GrobIterator&& other)
-  {
-    m_grob       = other.m_grob;
-    m_numCorners = other.m_numCorners;
-    return *this;
-  }
-
-	reference operator * ()
+	Grob& operator * ()
 	{
 		return m_grob;
 	}
 
-  const_reference operator * () const
+  Grob const& operator * () const
   {
     return m_grob;
   }
 
-	pointer operator -> ()
+	Grob* operator -> ()
 	{
 		return &m_grob;
 	}
 
-  const_pointer operator -> () const
+  Grob const* operator -> () const
   {
     return &m_grob;
   }
 
-	bool operator == (const GrobIterator& i) const
+	bool operator == (const GenericGrobIterator& i) const
 	{
 		return	m_grob.global_corner_array () == i.m_grob.global_corner_array ()
 				&&	m_grob.grob_type () == i.m_grob.grob_type ();
 	}
 
-	bool operator != (const GrobIterator& i) const
+	bool operator != (const GenericGrobIterator& i) const
 	{
 		return	m_grob.global_corner_array () != i.m_grob.global_corner_array ()
 				||	m_grob.grob_type () != i.m_grob.grob_type ();
 	}
 
-	GrobIterator& operator += (difference_type n)
+	GenericGrobIterator& operator += (difference_type n)
 	{
 		m_grob.set_global_corner_array (shifted_corner_array (n));
 		return *this;
 	}
 
-	GrobIterator& operator -= (difference_type n)
+	GenericGrobIterator& operator -= (difference_type n)
 	{
 		m_grob.set_global_corner_array (shifted_corner_array (-n));
 		return *this;
 	}
 
-	GrobIterator operator + (difference_type n)
+	GenericGrobIterator operator + (difference_type n) const
 	{
-		return GrobIterator (m_grob.grob_type(), shifted_corner_array (n));
+		return GenericGrobIterator (m_grob.grob_type(), shifted_corner_array (n));
 	}
 
-	GrobIterator operator - (difference_type n)
+	GenericGrobIterator operator - (difference_type n) const
 	{
-		return GrobIterator (m_grob.grob_type(), shifted_corner_array (-n));
+		return GenericGrobIterator (m_grob.grob_type(), shifted_corner_array (-n));
 	}
 
-	GrobIterator& operator ++ ()
+	GenericGrobIterator& operator ++ ()
 	{
 		m_grob.set_global_corner_array (shifted_corner_array (1));
 		return *this;
 	}
 
-	GrobIterator operator ++ (int)
+	GenericGrobIterator operator ++ (int)
 	{
-		GrobIterator i = *this;
+		GenericGrobIterator i = *this;
 		m_grob.set_global_corner_array (shifted_corner_array (1));
 		return i;
 	}
 
-	GrobIterator& operator -- ()
+	GenericGrobIterator& operator -- ()
 	{
 		m_grob.set_global_corner_array (shifted_corner_array (-1));
 		return *this;
 	}
 
-	GrobIterator operator -- (int)
+	GenericGrobIterator operator -- (int)
 	{
-		GrobIterator i = *this;
+		GenericGrobIterator i = *this;
 		m_grob.set_global_corner_array (shifted_corner_array (-1));
 		return i;
 	}
 
 private:
-	index_t* shifted_corner_array (difference_type n)
+  /** Note: This method always returns a non-const index array, even for const types.
+            The resulting array is however never used for manipulation and is instead
+            re-cast to the constness of the underlying type by all callers
+            The reason for this hack is to allow one iterator implementation for both
+            `Grob` and `ConstGrob`.*/
+	index_t* shifted_corner_array (difference_type n) const
 	{
-		return m_grob.global_corner_array () + n * m_numCorners;
+		return const_cast <index_t*> (m_grob.global_corner_array ()) + n * m_numCorners;
 	}
 
 	Grob m_grob;
 	index_t m_numCorners;
 };
+
+using GrobIterator = GenericGrobIterator <Grob>;
+using ConstGrobIterator = GenericGrobIterator <ConstGrob>;
 
 }//	end of namespace lume
 

--- a/lume/include/lume/grob_iterator.h
+++ b/lume/include/lume/grob_iterator.h
@@ -38,23 +38,61 @@ public:
 	using iterator_category = std::bidirectional_iterator_tag;
 	using value_type = Grob;
 	using difference_type = std::ptrdiff_t;
-	using pointer = const Grob*;
-	using reference = const Grob&;
+	using pointer = Grob*;
+  using const_pointer = const Grob*;
+	using reference = Grob&;
+  using const_reference = const Grob&;
 
-	GrobIterator (GrobType grobType, const index_t* globalCornerArray) :
+  GrobIterator () = default;
+  
+  GrobIterator (GrobIterator const& other)
+   : m_grob (other.m_grob)
+   , m_numCorners (other.m_numCorners)
+  {}
+
+  GrobIterator (GrobIterator&& other)
+   : m_grob (other.m_grob)
+   , m_numCorners (other.m_numCorners)
+  {}
+
+	GrobIterator (GrobType grobType, index_t* globalCornerArray) :
 		m_grob (grobType, globalCornerArray),
 		m_numCorners (m_grob.num_corners ())
 	{}
 
-	reference operator * () const
+  GrobIterator& operator = (GrobIterator const& other)
+  {
+    m_grob       = other.m_grob;
+    m_numCorners = other.m_numCorners;
+    return *this;
+  }
+
+  GrobIterator& operator = (GrobIterator&& other)
+  {
+    m_grob       = other.m_grob;
+    m_numCorners = other.m_numCorners;
+    return *this;
+  }
+
+	reference operator * ()
 	{
 		return m_grob;
 	}
 
-	reference operator -> () const
+  const_reference operator * () const
+  {
+    return m_grob;
+  }
+
+	pointer operator -> ()
 	{
-		return m_grob;
+		return &m_grob;
 	}
+
+  const_pointer operator -> () const
+  {
+    return &m_grob;
+  }
 
 	bool operator == (const GrobIterator& i) const
 	{
@@ -80,12 +118,12 @@ public:
 		return *this;
 	}
 
-	GrobIterator operator + (difference_type n) const
+	GrobIterator operator + (difference_type n)
 	{
 		return GrobIterator (m_grob.grob_type(), shifted_corner_array (n));
 	}
 
-	GrobIterator operator - (difference_type n) const
+	GrobIterator operator - (difference_type n)
 	{
 		return GrobIterator (m_grob.grob_type(), shifted_corner_array (-n));
 	}
@@ -117,7 +155,7 @@ public:
 	}
 
 private:
-	const index_t* shifted_corner_array (difference_type n) const
+	index_t* shifted_corner_array (difference_type n)
 	{
 		return m_grob.global_corner_array () + n * m_numCorners;
 	}

--- a/lume/include/lume/hierarchy.h
+++ b/lume/include/lume/hierarchy.h
@@ -34,73 +34,73 @@ namespace lume
 class Hierarchy
 {
 public:
-    struct Relation
+  struct Relation
+  {
+    class ChildIterator
     {
-        class ChildIterator
-        {
-        public:
-            ChildIterator (index_t index) : m_index (index) {}
+    public:
+      ChildIterator (index_t index) : m_index (index) {}
 
-            bool           operator != (const ChildIterator& i) const {return m_index != i.m_index;}
-            index_t        operator *  () const                       {return m_index;}
-            ChildIterator& operator ++ ()                             {++m_index; return *this;}
+      bool           operator != (const ChildIterator& i) const {return m_index != i.m_index;}
+      index_t        operator *  () const                       {return m_index;}
+      ChildIterator& operator ++ ()                             {++m_index; return *this;}
 
-        private:
-            index_t m_index;
-        };
-
-        Grob    parent;
-        index_t firstChild;
-        index_t numChildren;
-
-        ChildIterator begin () const {return ChildIterator (firstChild);}
-        ChildIterator end   () const {return ChildIterator (firstChild + numChildren);}
+    private:
+      index_t m_index;
     };
 
+    ConstGrob parent;
+    index_t firstChild;
+    index_t numChildren;
+
+    ChildIterator begin () const {return ChildIterator (firstChild);}
+    ChildIterator end   () const {return ChildIterator (firstChild + numChildren);}
+  };
+
 public:
-    Hierarchy (CSPMesh   parentMesh,
-               SPMesh    childMesh)
-        : m_parentMesh (std::move (parentMesh))
-        , m_childMesh  (std::move (childMesh))
-    {}
+  Hierarchy (CSPMesh   parentMesh,
+             SPMesh    childMesh)
+    : m_parentMesh (std::move (parentMesh))
+    , m_childMesh  (std::move (childMesh))
+  {}
 
-    Hierarchy (Hierarchy& other) = delete;
+  Hierarchy (Hierarchy& other) = delete;
 
-    Hierarchy (Hierarchy&& other)
-        : m_parentMesh (std::move (other.m_parentMesh))
-        , m_childMesh  (std::move (other.m_childMesh))
-    {
-        for(size_t i = 0; i < m_relationsByChildType.size (); ++i) {
-            m_relationsByChildType [i] = std::move (other.m_relationsByChildType [i]);
-        }
+  Hierarchy (Hierarchy&& other)
+    : m_parentMesh (std::move (other.m_parentMesh))
+    , m_childMesh  (std::move (other.m_childMesh))
+  {
+    for(size_t i = 0; i < m_relationsByChildType.size (); ++i) {
+      m_relationsByChildType [i] = std::move (other.m_relationsByChildType [i]);
     }
+  }
 
-    Mesh const& parent_mesh () const {return *m_parentMesh;}
-    Mesh&       child_mesh  ()       {return *m_childMesh;}
+  Mesh const& parent_mesh () const {return *m_parentMesh;}
+  Mesh&       child_mesh  ()       {return *m_childMesh;}
 
-    void reserve (GrobType childType, size_t const numParents)
-    {
-        m_relationsByChildType [childType].reserve (numParents);
-    }
+  void reserve (GrobType childType, size_t const numParents)
+  {
+    m_relationsByChildType [childType].reserve (numParents);
+  }
 
-    /** Returns an array of relations between parents and their consecutive children.*/
-    std::vector <Relation> const& relationsForChildType (GrobType childType)
-    {
-        return m_relationsByChildType [childType];
-    }
+  /** Returns an array of relations between parents and their consecutive children.*/
+  std::vector <Relation> const& relationsForChildType (GrobType childType)
+  {
+    return m_relationsByChildType [childType];
+  }
 
-    void add_relation (const Grob& parent,
-                       GrobType const childType,
-                       index_t const firstChild,
-                       index_t const numChildren)
-    {
-        m_relationsByChildType [childType].emplace_back (Relation {parent, firstChild, numChildren});
-    }
+  void add_relation (const ConstGrob& parent,
+                     GrobType const childType,
+                     index_t const firstChild,
+                     index_t const numChildren)
+  {
+    m_relationsByChildType [childType].emplace_back (Relation {parent, firstChild, numChildren});
+  }
 
 private:
-    CSPMesh   m_parentMesh;
-    SPMesh    m_childMesh;
-    std::array <std::vector <Relation>, NUM_GROB_TYPES> m_relationsByChildType;
+  CSPMesh   m_parentMesh;
+  SPMesh    m_childMesh;
+  std::array <std::vector <Relation>, NUM_GROB_TYPES> m_relationsByChildType;
 };
 
 }// end of namespace lume

--- a/lume/include/lume/math/grob_math.h
+++ b/lume/include/lume/math/grob_math.h
@@ -32,21 +32,21 @@ namespace lume::math
 
 template <class T>
 TupleWithStorage <T>
-GrobCenter (Grob const& grob, ConstTupleView <T> const& coords)
+GrobCenter (ConstGrob const& grob, ConstTupleView <T> const& coords)
 {
-    assert (grob.num_corners ());
+  assert (grob.num_corners ());
 
-    auto sum = TupleWithStorage <T>::uninitialized (coords.tuple_size ());
-    sum = T (0);
+  auto sum = TupleWithStorage <T>::uninitialized (coords.tuple_size ());
+  sum = T (0);
 
-    index_t const numCorners = grob.num_corners ();
-    for(index_t i = 0; i < numCorners; ++i) {
-        sum += coords [grob.corner (i)];
-    }
+  index_t const numCorners = grob.num_corners ();
+  for(index_t i = 0; i < numCorners; ++i) {
+    sum += coords [grob.corner (i)];
+  }
 
-    sum /= static_cast <T> (numCorners);
+  sum /= static_cast <T> (numCorners);
 
-    return sum;
+  return sum;
 }
 
 }// end of namespace lume::math

--- a/lume/include/lume/mesh.h
+++ b/lume/include/lume/mesh.h
@@ -142,12 +142,22 @@ public:
     annex_update (grobType);
   }
 
+  GrobArray& grobs (const GrobType grobType)
+  {
+    return grob_array (grobType);
+  }
+
   const GrobArray& grobs (const GrobType grobType) const
   {
     return grob_array (grobType);
   }
 
-  Grob grob (const GrobIndex& grobIndex) const
+  Grob grob (const GrobIndex& grobIndex)
+  {
+    return grobs (grobIndex.grob_type ()) [grobIndex.index ()];
+  }
+
+  ConstGrob grob (const GrobIndex& grobIndex) const
   {
     return grobs (grobIndex.grob_type ()) [grobIndex.index ()];
   }

--- a/lume/include/lume/topology.h
+++ b/lume/include/lume/topology.h
@@ -158,7 +158,7 @@ GrobArray ExtractGrobs (GrobHashMap <Value> const& grobHashMap,
 template <class Value>
 GrobArray ExtractGrobs (GrobHashMap <Value> const& grobHashMap,
                         GrobType const grobType,
-                        std::function <bool (Grob const&, Value const&)> const predicate);
+                        std::function <bool (ConstGrob const&, Value const&)> const predicate);
 
 /// Inserts all *grobs* in the specified grob set into the provided *hashMapInOut*.
 /** The grobs are numbered in sequential order according to when they were first encountered

--- a/lume/include/lume/topology_impl.h
+++ b/lume/include/lume/topology_impl.h
@@ -90,7 +90,7 @@ GrobArray ExtractGrobs (GrobHashMap <Value> const& grobHashMap,
 template <class Value>
 GrobArray ExtractGrobs (GrobHashMap <Value> const& grobHashMap,
                         GrobType const grobType,
-                        std::function <bool (Grob const&, Value const&)> const predicate)
+                        std::function <bool (ConstGrob const&, Value const&)> const predicate)
 {
   GrobArray grobs {grobType};
   for (auto const& [grob, value] : grobHashMap)

--- a/lume/include/lume/tuple_vector.h
+++ b/lume/include/lume/tuple_vector.h
@@ -88,12 +88,13 @@ public:
     inline T* data()                            {return m_vector.data ();}
     inline const T* data () const               {return m_vector.data ();}
 
-    inline void clear ()                                         {m_vector.clear();}
-    inline void resize (const size_type s)                       {m_vector.resize (s);}
-    inline void resize (const size_type s, const T& v)           {m_vector.resize (s, v);}
-    inline void set_num_tuples (const size_type num)             {m_vector.resize (num * tuple_size ());}
-    inline void set_num_tuples (const size_type num, const T& v) {m_vector.resize (num * tuple_size (), v);}
-    inline void reserve (const size_type s)                      {m_vector.reserve (s);}
+    inline void clear ()                                             {m_vector.clear();}
+    inline void resize (const size_type s)                           {m_vector.resize (s);}
+    inline void resize (const size_type s, const T& v)               {m_vector.resize (s, v);}
+    inline void set_num_tuples (const size_type num)                 {m_vector.resize (num * tuple_size ());}
+    inline void set_num_tuples (const size_type num, const T& v)     {m_vector.resize (num * tuple_size (), v);}
+    inline void reserve (const size_type s)                          {m_vector.reserve (s);}
+    inline iterator erase (const iterator begin, const iterator end) {return m_vector.erase (begin, end);}
 
     inline T& operator [] (const size_type i)             {return m_vector[i];}
     inline const T& operator [] (const size_type i) const {return m_vector[i];}

--- a/lume/src/lume/grob.cpp
+++ b/lume/src/lume/grob.cpp
@@ -1,6 +1,6 @@
 // This file is part of lume, a C++ library for lightweight unstructured meshes
 //
-// Copyright (C) 2018 Sebastian Reiter
+// Copyright (C) 2018, 2019 Sebastian Reiter
 // Copyright (C) 2018 G-CSC, Goethe University Frankfurt
 // Author: Sebastian Reiter <s.b.reiter@gmail.com>
 // All rights reserved.
@@ -24,3 +24,319 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <lume/grob.h>
+
+namespace lume
+{
+ConstGrob::ConstGrob (GrobType grobType, index_t const* corners) :
+  m_globCornerInds (corners),
+  m_cornerOffsets (impl::Array_16_4::ascending_order ()),
+  m_desc (grobType)
+{}
+
+ConstGrob::ConstGrob (ConstGrob const& other)
+  : m_globCornerInds {other.m_globCornerInds}
+  , m_cornerOffsets {other.m_cornerOffsets}
+  , m_desc {other.m_desc}
+{}
+
+ConstGrob::ConstGrob (Grob const& other)
+  : m_globCornerInds {other.global_corner_array ()}
+  , m_cornerOffsets {other.corner_offsets ()}
+  , m_desc {other.desc ()}
+{}
+
+ConstGrob::ConstGrob (GrobType grobType, index_t const* globCornerInds, const impl::Array_16_4& cornerOffsets) :
+  m_globCornerInds (globCornerInds),
+  m_cornerOffsets (cornerOffsets),
+  m_desc (grobType)
+{}
+
+void ConstGrob::reset (Grob const& other)
+{
+  reset (ConstGrob (other));
+}
+
+void ConstGrob::reset (ConstGrob const& other)
+{
+  m_globCornerInds = other.m_globCornerInds;
+  m_cornerOffsets = other.m_cornerOffsets;
+  m_desc = other.m_desc;
+}
+
+void ConstGrob::set_global_corner_array (index_t const* cornerArray)
+{
+  m_globCornerInds = cornerArray;
+}
+
+/// only compares corners, ignores order and orientation.
+bool ConstGrob::operator == (const ConstGrob& g) const
+{
+  if (m_desc.grob_type() != g.m_desc.grob_type())
+    return false;
+
+  CornerIndexContainer gCorners;
+  g.collect_corners (gCorners);
+
+  const index_t numCorners = num_corners ();
+  for(index_t i = 0; i < numCorners; ++i) {
+    bool gotOne = false;
+    const index_t c = corner(i);
+    for(index_t j = 0; j < numCorners; ++j) {
+      if(c == gCorners [j]){
+        gotOne = true;
+        break;
+      }
+    }
+
+    if (!gotOne)
+      return false;
+  }
+
+  return true;
+}
+
+bool ConstGrob::operator != (const ConstGrob& g) const
+{
+  return !((*this) == g);
+}
+
+index_t ConstGrob::operator [] (const index_t i) const
+{
+  return corner (i);
+}
+
+index_t ConstGrob::dim () const        {return m_desc.dim ();}
+
+GrobType ConstGrob::grob_type () const {return m_desc.grob_type ();}
+
+GrobDesc ConstGrob::desc () const      {return m_desc;}
+
+index_t const* ConstGrob::global_corner_array () const
+{
+  return m_globCornerInds;
+}
+
+index_t ConstGrob::num_corners () const         {return m_desc.num_corners();}
+
+/// returns the global index of the i-th corner
+index_t ConstGrob::corner (const index_t i) const
+{
+  assert (m_globCornerInds != nullptr);
+  return m_globCornerInds [m_cornerOffsets.get(i)];
+}
+
+/// collects the global indices of corners
+/** \param cornersOut Array of size `Grob::max_num_corners(). Only the first
+   *                      `Grob::num_corners()` entries are filled
+ *
+ * \returns The number of corners of the specified side
+ */
+index_t ConstGrob::collect_corners (CornerIndexContainer& cornersOut) const
+{
+  assert (m_globCornerInds != nullptr);
+  const index_t numCorners = num_corners();
+  for(index_t i = 0; i < numCorners; ++i)
+    cornersOut[i] = static_cast<index_t> (m_globCornerInds [m_cornerOffsets.get(i)]);
+  return numCorners;
+}
+
+index_t ConstGrob::num_sides (const index_t sideDim) const
+{
+  return m_desc.num_sides(sideDim);
+}
+
+GrobDesc ConstGrob::side_desc (const index_t sideDim, const index_t sideIndex) const
+{
+  return m_desc.side_desc (sideDim, sideIndex);
+}
+
+ConstGrob ConstGrob::side (const index_t sideDim, const index_t sideIndex) const
+{
+  assert (m_globCornerInds != nullptr);
+  impl::Array_16_4 cornerOffsets;
+  const index_t numCorners = m_desc.side_desc(sideDim, sideIndex).num_corners();
+  const index_t* locCorners = m_desc.local_side_corners (sideDim, sideIndex);
+  // LOGT(side, "side " << sideIndex << "(dim: " << sideDim << ", num corners: " << numCorners << "): ");
+  for(index_t i = 0; i < numCorners; ++i){
+    // LOG(locCorners[i] << " ");
+    cornerOffsets.set (i, m_cornerOffsets.get(locCorners[i]));
+  }
+  // LOG("\n");
+
+  return ConstGrob (m_desc.side_type (sideDim, sideIndex), m_globCornerInds, cornerOffsets);
+}
+
+/// returns the index of the side which corresponds to the given grob
+/** if no such side was found, 'lume::NO_INDEX' is returned.*/
+index_t ConstGrob::find_side (const ConstGrob& sideGrob) const
+{
+  const index_t sideDim = sideGrob.dim();
+  const index_t numSides = num_sides (sideDim);
+  for(index_t iside = 0; iside < numSides; ++iside) {
+    if (sideGrob == side (sideDim, iside))
+      return iside;
+  }
+  return NO_INDEX;
+}
+
+const impl::Array_16_4& ConstGrob::corner_offsets () const
+{
+  return m_cornerOffsets;
+}
+
+Grob::Grob (GrobType grobType, index_t* corners)
+  : m_constGrob (grobType, corners)
+{}
+
+Grob::Grob (Grob const& other)
+  : m_constGrob (other)
+{}
+
+Grob::Grob (GrobType grobType, index_t* globCornerInds, const impl::Array_16_4& cornerOffsets)
+  : m_constGrob (grobType, globCornerInds, cornerOffsets)
+{}
+
+void Grob::reset (Grob const& other)
+{
+  m_constGrob.reset (other);
+}
+
+void Grob::set_global_corner_array (index_t* cornerArray)
+{
+  m_constGrob.set_global_corner_array (cornerArray);
+}
+
+Grob& Grob::operator = (Grob const& other)
+{
+  return operator = (ConstGrob (other));
+}
+
+Grob& Grob::operator = (ConstGrob const& other)
+{
+  assert (global_corner_array () != nullptr);
+  assert (other.global_corner_array () != nullptr);
+  assert (other.grob_type () == grob_type ());
+  assert (other.num_corners () == num_corners ());
+
+  index_t const numCorners = num_corners ();
+  for (index_t i = 0; i < numCorners; ++i)
+  {
+    set_corner (i, other [i]);
+  }
+
+  return *this;
+}
+
+/// only compares corners, ignores order and orientation.
+bool Grob::operator == (const Grob& other) const
+{
+  return m_constGrob == other;
+}
+
+bool Grob::operator == (const ConstGrob& other) const
+{
+  return m_constGrob == other;
+}
+
+bool Grob::operator != (const Grob& other) const
+{
+  return m_constGrob != other;
+}
+
+bool Grob::operator != (const ConstGrob& other) const
+{
+  return m_constGrob != other;
+}
+
+index_t Grob::operator [] (const index_t i) const
+{
+  return corner (i);
+}
+
+index_t Grob::dim () const
+{
+  return m_constGrob.dim ();
+}
+
+GrobType Grob::grob_type () const
+{
+  return m_constGrob.grob_type ();
+}
+
+GrobDesc Grob::desc () const
+{
+  return m_constGrob.desc ();
+}
+
+index_t const* Grob::global_corner_array () const
+{
+  return m_constGrob.global_corner_array ();
+}
+
+index_t* Grob::global_corner_array ()
+{
+  return const_cast <index_t*> (m_constGrob.global_corner_array ());
+}
+
+index_t Grob::num_corners () const
+{
+  return m_constGrob.num_corners ();
+}
+
+/// returns the global index of the i-th corner
+index_t Grob::corner (const index_t i) const
+{
+  return m_constGrob.corner (i);
+}
+
+/// sets the point index of the i-th corner
+void Grob::set_corner (const index_t cornerIndex, const index_t pointIndex)
+{
+  assert (global_corner_array () != nullptr);
+  assert (cornerIndex < num_corners ());
+  global_corner_array () [m_constGrob.corner_offsets ().get(cornerIndex)] = pointIndex;
+}
+
+/// collects the global indices of corners
+/** \param cornersOut Array of size `Grob::max_num_corners(). Only the first
+   *                      `Grob::num_corners()` entries are filled
+ *
+ * \returns The number of corners of the specified side
+ */
+index_t Grob::collect_corners (CornerIndexContainer& cornersOut) const
+{
+  return m_constGrob.collect_corners (cornersOut);
+}
+
+index_t Grob::num_sides (const index_t sideDim) const
+{
+  return m_constGrob.num_sides(sideDim);
+}
+
+GrobDesc Grob::side_desc (const index_t sideDim, const index_t sideIndex) const
+{
+  return m_constGrob.side_desc (sideDim, sideIndex);
+}
+
+Grob Grob::side (const index_t sideDim, const index_t sideIndex) const
+{
+  auto const cgrob = m_constGrob.side (sideDim, sideIndex);
+  return Grob (cgrob.grob_type (),
+               const_cast <index_t*> (cgrob.global_corner_array ()),
+               cgrob.corner_offsets ());
+}
+
+/// returns the index of the side which corresponds to the given grob
+/** if no such side was found, 'lume::NO_INDEX' is returned.*/
+index_t Grob::find_side (const Grob& sideGrob) const
+{
+  return m_constGrob.find_side (sideGrob);
+}
+
+const impl::Array_16_4& Grob::corner_offsets () const
+{
+  return m_constGrob.corner_offsets ();
+}
+
+}// end of namespace


### PR DESCRIPTION
GrobArrays did not feature erase functionality. In order to provide stl conformant erase on GrobIterators, the Grob type had to be reworked into a reference type, i.e. assigning a grob to another grob changes the data that is referenced by the grob and no longer just the location of the data to which the grob points.
To still allow references, ConstGrob and ConstGrobIterator types have been introduced and GrobHash and GrobHashMap have been reworked to operate on ConstGrobs.